### PR TITLE
jQuery を v3.6.0 にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express-session": "1.17.3",
     "helmet": "5.0.2",
     "http-errors": "~1.6.2",
-    "jquery": "^3.4.1",
+    "jquery": "3.6.0",
     "morgan": "~1.9.0",
     "passport": "0.6.0",
     "passport-github2": "0.1.12",


### PR DESCRIPTION
jQuery を v3.6.0 にアップデートしました。
（ https://github.com/nnn-training/change-repo-contents-all を使って作成しました）